### PR TITLE
SEAS-91

### DIFF
--- a/R/SeaSondeRAPM.R
+++ b/R/SeaSondeRAPM.R
@@ -162,6 +162,17 @@ SeaSondeRAPM_creation_step_text <- function(file_path) {
   glue::glue("{Sys.time()}: Created from {file_path}.")
 }
 
+SeaSondeRAPM_antenna_bearing_override_step_text <- function(antenna_bearing) {
+
+  glue::glue("{Sys.time()}: AntennaBearing overriden with value {antenna_bearing}.")
+
+}
+
+SeaSondeRAPM_smoothing_step_text <- function(smoothing){
+
+  glue::glue("{Sys.time()}: APM smoothed with smoothing {smoothing}.")
+
+}
 
 #### Validation ####
 
@@ -1025,6 +1036,22 @@ seasonder_getSeaSondeRAPM_FileID <- function(seasonde_apm_obj) {
   return(attributes(seasonde_apm_obj)$FileID)
 }
 
+#### Methods ####
+
+#'@export
+seasonder_smoothAPM <- function(seasonder_apm_object, smoothing){
+
+  seasonder_apm_object[1,] <- complex(real = slider::slide_mean(pracma::Real(seasonder_apm_object[1,]),before = smoothing, na_rm = T), imaginary =
+                                              slider::slide_mean(pracma::Imag(seasonder_apm_object[1,]),before = smoothing, na_rm = T))
+
+  seasonder_apm_object[2,] <- complex(real = slider::slide_mean(pracma::Real(seasonder_apm_object[2,]),before = smoothing, na_rm = T), imaginary =
+                                              slider::slide_mean(pracma::Imag(seasonder_apm_object[2,]),before = smoothing, na_rm = T))
+
+  seasonder_apm_object %<>% seasonder_setSeaSondeRAPM_ProcessingSteps(SeaSondeRAPM_smoothing_step_text(smoothing))
+
+  return(seasonder_apm_object)
+
+}
 
 #### File Reading ####
 
@@ -1176,6 +1203,10 @@ seasonder_readSeaSondeRAPMFile <- function(file_path, override_antenna_bearing =
 
 
   out %<>% seasonder_setSeaSondeRAPM_ProcessingSteps(SeaSondeRAPM_creation_step_text(file_path))
+
+  if (!is.null(override_antenna_bearing)) {
+    out  %<>% seasonder_setSeaSondeRAPM_ProcessingSteps(SeaSondeRAPM_antenna_bearing_override_step_text(override_antenna_bearing))
+  }
 
   # Validar los atributos después de la lectura
   seasonder_validateAttributesSeaSondeRAPM(out)

--- a/tests/testthat/test-SeaSondeRRadials.R
+++ b/tests/testthat/test-SeaSondeRRadials.R
@@ -303,11 +303,8 @@ plot_radials(test$range_cell,test$bearing,test$radial_v*100)
 
       smoothing <- 20
 
-      smoothed_seasonder_apm_obj[1,] <- complex(real = slider::slide_mean(pracma::Real(smoothed_seasonder_apm_obj[1,]),before = smoothing, na_rm = T), imaginary =
-                                         slider::slide_mean(pracma::Imag(smoothed_seasonder_apm_obj[1,]),before = smoothing, na_rm = T))
+      smoothed_seasonder_apm_obj %<>% seasonder_smoothAPM(smoothing)
 
-      smoothed_seasonder_apm_obj[2,] <- complex(real = slider::slide_mean(pracma::Real(smoothed_seasonder_apm_obj[2,]),before = smoothing, na_rm = T), imaginary =
-                                         slider::slide_mean(pracma::Imag(smoothed_seasonder_apm_obj[2,]),before = smoothing, na_rm = T))
 
       # combined_apm_obj <- seasonder_apm_obj
       # combined_apm_obj <- trimmed_seasonder_apm_obj
@@ -561,13 +558,7 @@ to.plot %>% dplyr::group_by(range) %>% dplyr::summarise(P = mean(P)) %>% ggplot2
 
       seasonder_apm_obj[2,] <- seasonder_apm_obj[2,]*amp2*exp(1i*phasec2*pi/180)
 
-      #     smoothing <- 20
-      #
-      #     seasonder_apm_obj[1,] <- complex(real = slider::slide_mean(pracma::Real(seasonder_apm_obj[1,]),before = smoothing, na_rm = T), imaginary =
-      # slider::slide_mean(pracma::Imag(seasonder_apm_obj[1,]),before = smoothing, na_rm = T))
-      #
-      #     seasonder_apm_obj[2,] <- complex(real = slider::slide_mean(pracma::Real(seasonder_apm_obj[2,]),before = smoothing, na_rm = T), imaginary =
-      #                                        slider::slide_mean(pracma::Imag(seasonder_apm_obj[2,]),before = smoothing, na_rm = T))
+
 
 
       plot(attr(seasonder_apm_obj, "BEAR",exact = T),Arg(seasonder_apm_obj[1,])*180/pi,xlim = c(-180,180),ylim = c(-180, 180))
@@ -774,13 +765,7 @@ describe("radials computation",{
 
     seasonder_apm_obj <- seasonder_readSeaSondeRAPMFile(here::here("tests/testthat/data/TORA/IdealPattern.txt"))
 
-    #     smoothing <- 10
-    #
-    #     seasonder_apm_obj[1,] <- complex(real = slider::slide_mean(pracma::Real(seasonder_apm_obj[1,]),before = smoothing, na_rm = T), imaginary =
-    # slider::slide_mean(pracma::Imag(seasonder_apm_obj[1,]),before = smoothing, na_rm = T))
-    #
-    #     seasonder_apm_obj[2,] <- complex(real = slider::slide_mean(pracma::Real(seasonder_apm_obj[2,]),before = smoothing, na_rm = T), imaginary =
-    #                                        slider::slide_mean(pracma::Imag(seasonder_apm_obj[2,]),before = smoothing, na_rm = T))
+
 
     plot(attr(seasonder_apm_obj, "BEAR",exact = T),Mod(seasonder_apm_obj[2,]),xlim = c(-180,180))
     plot(attr(seasonder_apm_obj, "BEAR",exact = T),Arg(seasonder_apm_obj[2,]),xlim = c(-180,180))


### PR DESCRIPTION
Implemented method for APM smoothing. Added processing step for antenna bearing override.

Implemented:

- SeaSondeRAPM_antenna_bearing_step_text
- SeaSondeRAPM_smoothing_step_text
- seasonder_smoothAPM

Updated:

-seasonder_readSeaSondeRAPMFile