### PR TITLE
SEAS-97

### DIFF
--- a/R/SeaSondeRAPM.R
+++ b/R/SeaSondeRAPM.R
@@ -199,6 +199,11 @@ SeaSondeRAPM_amplitude_factors_override_step_text <- function(amplitude_factors)
 
 }
 
+SeaSondeRAPM_SiteOrigin_override_step_text <- function(SiteOrigin) {
+
+  glue::glue("{Sys.time()}: SiteOrigin overriden with Latitude {SiteOrigin[1]} and Longitude {SiteOrigin[2]}.")
+
+}
 
 #### Validation ####
 
@@ -1212,7 +1217,7 @@ parse_metadata_line <- function(line) {
 #' @importFrom magrittr %<>%
 #' @seealso \code{\link{seasonder_createSeaSondeRAPM}}
 #' @seealso \code{\link{seasonder_validateAttributesSeaSondeRAPM}}
-seasonder_readSeaSondeRAPMFile <- function(file_path, override_antenna_bearing = NULL, override_phase_corrections = NULL, override_amplitude_factors = NULL, ...) {
+seasonder_readSeaSondeRAPMFile <- function(file_path, override_antenna_bearing = NULL, override_phase_corrections = NULL, override_amplitude_factors = NULL, override_SiteOrigin = NULL, ...) {
 
   lines <- readLines(file_path)
   num_angles <- as.integer(lines[1])
@@ -1330,6 +1335,13 @@ out %<>% seasonder_setSeaSondeRAPM_PhaseCorrections(override_phase_corrections)
 
   }
 
+  if (!is.null(override_SiteOrigin)) {
+
+      out %<>% seasonder_setSeaSondeRAPM_SiteOrigin(override_SiteOrigin)
+      out  %<>% seasonder_setSeaSondeRAPM_ProcessingSteps(SeaSondeRAPM_SiteOrigin_override_step_text(override_SiteOrigin))
+
+
+  }
 
   # Validar los atributos después de la lectura
   seasonder_validateAttributesSeaSondeRAPM(out)

--- a/tests/testthat/test-SeaSondeRAPM.R
+++ b/tests/testthat/test-SeaSondeRAPM.R
@@ -261,7 +261,7 @@ describe("seasonder_validateAttributesSeaSondeRAPM",{
 
 describe("file reading",{
 
-  it("File reading works", {
+  test_that("File reading works", {
     file_path <- here::here("tests/testthat/data/MeasPattern.txt")
     msg <- glue::glue("2022-01-02 03:45:03: Created from {file_path}.")
     mk <- mockthat::mock(msg)
@@ -275,5 +275,17 @@ describe("file reading",{
     expect_snapshot_value(test,style ="serialize")
   })
 
+  test_that("longitude and latitude override works",{
 
+
+    file_path <- here::here("tests/testthat/data/TORA/IdealPattern.txt")
+
+    target <- c(Latitude = 42, Longitude = -8)
+    test <- seasonder_readSeaSondeRAPMFile(file_path,
+                                           override_SiteOrigin = target,
+) %>% seasonder_getSeaSondeRAPM_SiteOrigin()
+
+expect_equal(test,target)
+
+  })
 })


### PR DESCRIPTION
Override SiteOrigin in APM object

Implemented:

- SeaSondeRAPM_SiteOrigin_override_step_text

Updated:

- seasonder_readSeaSondeRAPMFile